### PR TITLE
Fix XMLElement.getChildren(path)

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -3497,9 +3497,9 @@
           return this.getChildren(items[offset]);
         }
         var matches = this.getChildren(items[offset]);
-        var kidMatches;
+        var kidMatches = [];
         for (var i = 0; i < matches.length; i++) {
-          kidMatches = matches[i].getChildrenRecursive(items, offset+1);
+          kidMatches = kidMatches.concat(matches[i].getChildrenRecursive(items, offset+1));
         }
         return kidMatches;
       },


### PR DESCRIPTION
This fixes bug:

https://processing-js.lighthouseapp.com/projects/41284/tickets/987-xmlelementgetchildrenpath-not-returning-all-the-children#ticket-987-2

Cheers,
ricard
