### PR TITLE
default width/height & internal error console log

### DIFF
--- a/processing.js
+++ b/processing.js
@@ -15,13 +15,26 @@
 
 
 (function(window, document, Math, undef) {
+	
+  // stores the error if any occurred.
+  // use it like this: if(window.error) { ... }
+  var error = 0;
+  function throwError(msg) {
+	Processing.logger.log(msg);
+	if(this.error) {
+		// add error
+		this.error = this.error + '\n' + msg;
+	} else {
+		this.error = msg;
+	}
+  }
 
   var nop = function(){};
 
   var debug = (function() {
     if ("console" in window) {
       return function(msg) {
-        window.console.log('Processing.js: ' + msg);
+		window.console.log('Processing.js: ' + msg);
       };
     }
     return nop();
@@ -451,7 +464,7 @@
         return obj[index];
       };
     } else {
-      throw "Unable to iterate: " + obj;
+      throwError("Unable to iterate: " + obj);
     }
   };
 
@@ -543,13 +556,13 @@
             if (arg0 >= 0 && arg0 <= array.length) {
               array.splice(arg0, 0, arguments[1]); // for add(i, Object)
             } else {
-              throw(arg0 + " is not a valid index");
+              throwError(arg0 + " is not a valid index");
             }
           } else {
-            throw(typeof arg0 + " is not a number");
+            throwError(typeof arg0 + " is not a number");
           }
         } else {
-          throw("Please use the proper number of parameters.");
+          throwError("Please use the proper number of parameters.");
         }
       };
       /**
@@ -570,7 +583,7 @@
         var it;
         if (typeof arg1 === "number") {
           if (arg1 < 0 || arg1 > array.length) {
-            throw("Index out of bounds for addAll: " + arg1 + " greater or equal than " + array.length);
+            throwError("Index out of bounds for addAll: " + arg1 + " greater or equal than " + array.length);
           }
           it = new ObjectIterator(arg2);
           while (it.hasNext()) {
@@ -599,13 +612,13 @@
             if (arg0 >= 0 && arg0 < array.length) {
               array.splice(arg0, 1, arguments[1]);
             } else {
-              throw(arg0 + " is not a valid index.");
+              throwError(arg0 + " is not a valid index.");
             }
           } else {
-            throw(typeof arg0 + " is not a number");
+            throwError(typeof arg0 + " is not a number");
           }
         } else {
-          throw("Please use the proper number of parameters.");
+          throwError("Please use the proper number of parameters.");
         }
       };
 
@@ -1514,7 +1527,7 @@
 
     function createUnsupportedFunc(n) {
       return function() {
-        throw "Processing.js does not support " + n + ".";
+        throwError("Processing.js does not support " + n + ".");
       };
     }
 
@@ -1877,7 +1890,7 @@
   var Processing = this.Processing = function(aCanvas, aCode) {
     // Previously we allowed calling Processing as a func instead of ctor, but no longer.
     if (!(this instanceof Processing)) {
-      throw("called Processing constructor as if it were a function: missing 'new'.");
+      throwError("called Processing constructor as if it were a function: missing 'new'.");
     }
 
     var curElement,
@@ -1891,7 +1904,7 @@
     }
 
     if (!(curElement instanceof HTMLCanvasElement)) {
-      throw("called Processing constructor without passing canvas element reference or id.");
+      throwError("called Processing constructor without passing canvas element reference or id.");
     }
 
     function unimplemented(s) {
@@ -2675,14 +2688,14 @@
       curContext.shaderSource(vertexShaderObject, vetexShaderSource);
       curContext.compileShader(vertexShaderObject);
       if (!curContext.getShaderParameter(vertexShaderObject, curContext.COMPILE_STATUS)) {
-        throw curContext.getShaderInfoLog(vertexShaderObject);
+        throwError(curContext.getShaderInfoLog(vertexShaderObject));
       }
 
       var fragmentShaderObject = curContext.createShader(curContext.FRAGMENT_SHADER);
       curContext.shaderSource(fragmentShaderObject, fragmentShaderSource);
       curContext.compileShader(fragmentShaderObject);
       if (!curContext.getShaderParameter(fragmentShaderObject, curContext.COMPILE_STATUS)) {
-        throw curContext.getShaderInfoLog(fragmentShaderObject);
+        throwError(curContext.getShaderInfoLog(fragmentShaderObject));
       }
 
       var programObject = curContext.createProgram();
@@ -2690,7 +2703,7 @@
       curContext.attachShader(programObject, fragmentShaderObject);
       curContext.linkProgram(programObject);
       if (!curContext.getProgramParameter(programObject, curContext.LINK_STATUS)) {
-        throw "Error linking shaders.";
+        throwError("Error linking shaders.");
       }
 
       return programObject;
@@ -3466,7 +3479,7 @@
         this.fillOpacity         = 1;
 
         if (this.element.getName() !== "svg") {
-          throw("root is not <svg>, it's <" + this.element.getName() + ">");
+          throwError("root is not <svg>, it's <" + this.element.getName() + ">");
         }
       }
       else if (arguments.length === 2) {
@@ -3555,8 +3568,7 @@
           this.height = 1;
 
           //show warning
-          throw("The width and/or height is not " +
-                "readable in the <svg> tag of this file.");
+          throwError("The width and/or height is not " + "readable in the <svg> tag of this file.");
         }
       }
       this.parseColors(this.element);
@@ -4085,7 +4097,7 @@
         this.parsePathVertex(x2 + ((cx-x2)*2/3), y2 + ((cy-y2)*2/3));
         this.parsePathVertex(x2, y2);
       } else {
-        throw ("Path must start with M/m");
+        throwError("Path must start with M/m");
       }
     };
     /**
@@ -4101,7 +4113,7 @@
         this.parsePathVertex(x2, y2);
         this.parsePathVertex(x3, y3);
       } else {
-        throw ("Path must start with M/m");
+        throwError("Path must start with M/m");
       }
     };
     /**
@@ -4118,7 +4130,7 @@
         // or curContext.lineTo
         this.vertices[this.vertices.length-1]["moveTo"] = false;
       } else {
-        throw ("Path must start with M/m");
+        throwError("Path must start with M/m");
       }
     };
 
@@ -4175,7 +4187,7 @@
             this.vertices.push(verts);
           }
         } else {
-          throw("Error parsing polygon points: odd number of coordinates provided");
+          throwError("Error parsing polygon points: odd number of coordinates provided");
         }
       }
     };
@@ -4192,7 +4204,7 @@
       this.params[2] = this.element.getFloatAttribute("width");
       this.params[3] = this.element.getFloatAttribute("height");
       if (this.params[2] < 0 || this.params[3] < 0) {
-        throw("svg error: negative width or height found while parsing <rect>");
+        throwError("svg error: negative width or height found while parsing <rect>");
       }
     };
     /**
@@ -4213,13 +4225,13 @@
       if (val) {
         rx = ry = this.element.getFloatAttribute("r");
         if (rx < 0) {
-          throw("svg error: negative radius found while parsing <circle>");
+          throwError("svg error: negative radius found while parsing <circle>");
         }
       } else {
         rx = this.element.getFloatAttribute("rx");
         ry = this.element.getFloatAttribute("ry");
         if (rx < 0 || ry < 0) {
-          throw("svg error: negative x-axis radius or y-axis radius found while parsing <ellipse>");
+          throwError("svg error: negative x-axis radius or y-axis radius found while parsing <ellipse>");
         }
       }
       this.params[0] -= rx;
@@ -4764,11 +4776,11 @@
           if (elements) {
             this.parseChildrenRecursive(null, elements);
           } else {
-            throw ("Error loading document");
+            throwError("Error loading document");
           }
           return this;
         } catch(e) {
-          throw(e);
+          throwError(e);
         }
       },
       /**
@@ -6826,7 +6838,7 @@
         if (dest[j] !== undef) {
           dest[j] = src[i];
         } else {
-          throw "array index out of bounds exception";
+          throwError("array index out of bounds exception");
         }
       }
     };
@@ -7835,7 +7847,7 @@
     * @see pushMatrix
     */
     Drawing2D.prototype.rotateZ = function() {
-      throw "rotateZ() is not supported in 2D mode. Use rotate(float) instead.";
+      throwError("rotateZ() is not supported in 2D mode. Use rotate(float) instead.");
     };
 
     Drawing3D.prototype.rotateZ = function(angleInRadians) {
@@ -7988,7 +8000,7 @@
         curTextDescent = oldState.curTextDescent;
         curTextLeading = oldState.curTextLeading;
       } else {
-        throw "Too many popStyle() without enough pushStyle()";
+        throwError("Too many popStyle() without enough pushStyle()");
       }
     };
 
@@ -8234,7 +8246,7 @@
           curSketch.onFrameEnd();
         } catch(e_loop) {
           window.clearInterval(looping);
-          throw e_loop;
+          throwError(e_loop);
         }
       }, curMsPerFrame);
       doLoop = true;
@@ -8349,7 +8361,7 @@
           x = arguments[1];
           y = arguments[2];
           if (x < 0 || y < 0 || y >= image.height || x >= image.width) {
-            throw "x and y must be non-negative and less than the dimensions of the image";
+            throwError("x and y must be non-negative and less than the dimensions of the image");
           }
         } else {
           x = image.width >>> 1;
@@ -8502,7 +8514,7 @@
       while (i >= 0) {
         var ch = binaryString[i--];
         if (ch !== '0' && ch !== '1') {
-          throw "the value passed into unbinary was not an 8 bit binary number";
+          throwError("the value passed into unbinary was not an 8 bit binary number");
         }
         if (ch === '1') {
           result += mask;
@@ -9300,7 +9312,7 @@
         }
         return ret;
       }
-      throw "char() may receive only one argument of type int, byte, int[], or byte[].";
+      throwError("char() may receive only one argument of type int, byte, int[], or byte[].");
     };
 
     // Processing doc claims good argument types are: int, char, byte, boolean,
@@ -9389,7 +9401,7 @@
 
     p.__instanceof = function(obj, type) {
       if (typeof type !== "function") {
-        throw "Function is expected as type argument for instanceof operator";
+        throwError("Function is expected as type argument for instanceof operator");
       }
 
       if (typeof obj === "string") {
@@ -9620,7 +9632,8 @@
       }
       var numbers = arguments.length === 1 ? arguments[0] : arguments; // if single argument, array is used
       if (! ("length" in numbers && numbers.length > 0)) {
-        throw "Non-empty array is expected";
+        var errMsg = "Non-empty array is expected";
+		throwError(errMsg);
       }
       var max = numbers[0],
         count = numbers.length;
@@ -9650,8 +9663,9 @@
       }
       var numbers = arguments.length === 1 ? arguments[0] : arguments; // if single argument, array is used
       if (! ("length" in numbers && numbers.length > 0)) {
-        throw "Non-empty array is expected";
-      }
+        var errMsg = "Non-empty array is expected";
+		throwError(errMsg);
+	  }
       var min = numbers[0],
         count = numbers.length;
       for (var i = 1; i < count; ++i) {
@@ -10203,7 +10217,8 @@
 
       return function size(aWidth, aHeight, aMode) {
         if (size3DCalled) {
-          throw "Multiple calls to size() for 3D renders are not allowed.";
+          var errMsg = "Multiple calls to size() for 3D renders are not allowed.";
+		  throwError(errMsg);
         }
         size3DCalled = true;
 
@@ -10238,7 +10253,8 @@
         }
 
         if (!curContext) {
-          throw "WebGL context is not supported on this browser.";
+          var errMsg = "WebGL context is not supported on this browser.";
+		  throwError(errMsg);
         }
 
         // Set defaults
@@ -10378,7 +10394,8 @@
 
     Drawing3D.prototype.ambientLight = function(r, g, b, x, y, z) {
       if (lightCount === PConstants.MAX_LIGHTS) {
-        throw "can only create " + PConstants.MAX_LIGHTS + " lights";
+        var errMsg = "can only create " + PConstants.MAX_LIGHTS + " lights";
+		throwError(errMsg);
       }
 
       var pos = new PVector(x, y, z);
@@ -10433,7 +10450,8 @@
 
     Drawing3D.prototype.directionalLight = function(r, g, b, nx, ny, nz) {
       if (lightCount === PConstants.MAX_LIGHTS) {
-        throw "can only create " + PConstants.MAX_LIGHTS + " lights";
+        var errMsg = "can only create " + PConstants.MAX_LIGHTS + " lights";
+		throwError(errMsg);
       }
 
       curContext.useProgram(programObject3D);
@@ -10584,7 +10602,8 @@
 
     Drawing3D.prototype.pointLight = function(r, g, b, x, y, z) {
       if (lightCount === PConstants.MAX_LIGHTS) {
-        throw "can only create " + PConstants.MAX_LIGHTS + " lights";
+        var errMsg = "can only create " + PConstants.MAX_LIGHTS + " lights";
+		throwError(errMsg);
       }
 
       // Place the point in view space once instead of once per vertex
@@ -10660,7 +10679,8 @@
 
     Drawing3D.prototype.spotLight = function(r, g, b, x, y, z, nx, ny, nz, angle, concentration) {
       if (lightCount === PConstants.MAX_LIGHTS) {
-        throw "can only create " + PConstants.MAX_LIGHTS + " lights";
+        var errMsg = "can only create " + PConstants.MAX_LIGHTS + " lights";
+		throwError(errMsg);
       }
 
       curContext.useProgram(programObject3D);
@@ -10726,12 +10746,14 @@
      * @see scale
      */
     Drawing2D.prototype.beginCamera = function() {
-      throw ("beginCamera() is not available in 2D mode");
+      var errMsg = "beginCamera() is not available in 2D mode";
+	  throwError(errMsg);
     };
 
     Drawing3D.prototype.beginCamera = function() {
       if (manipulatingCamera) {
-        throw ("You cannot call beginCamera() again before calling endCamera()");
+        var errMsg = "You cannot call beginCamera() again before calling endCamera()";
+		throwError(errMsg);
       }
       manipulatingCamera = true;
       modelView = cameraInv;
@@ -10745,12 +10767,14 @@
      * @see beginCamera
      */
     Drawing2D.prototype.endCamera = function() {
-      throw ("endCamera() is not available in 2D mode");
+      var errMsg = "endCamera() is not available in 2D mode";
+	  throwError(errMsg);
     };
 
     Drawing3D.prototype.endCamera = function() {
       if (!manipulatingCamera) {
-        throw ("You cannot call endCamera() before calling beginCamera()");
+        var errMsg = "You cannot call endCamera() before calling beginCamera()";
+		throwError(errMsg);
       }
       modelView.set(cam);
       modelViewInv.set(cameraInv);
@@ -10881,7 +10905,8 @@
      * @see perspective
      */
     Drawing2D.prototype.frustum = function() {
-      throw("Processing.js: frustum() is not supported in 2D mode");
+      var errMsg = "Processing.js: frustum() is not supported in 2D mode";
+	  throwError(errMsg);
     };
 
     Drawing3D.prototype.frustum = function(left, right, bottom, top, near, far) {
@@ -12933,7 +12958,8 @@
       isBezier = true;
       var vert = [];
       if (firstVert) {
-        throw ("vertex() must be used at least once before calling bezierVertex()");
+        var errMsg = "vertex() must be used at least once before calling bezierVertex()";
+		throwError(errMsg);
       }
 
       for (var i = 0; i < arguments.length; i++) {
@@ -12947,7 +12973,8 @@
       isBezier = true;
       var vert = [];
       if (firstVert) {
-        throw ("vertex() must be used at least once before calling bezierVertex()");
+        var errMsg = "vertex() must be used at least once before calling bezierVertex()";
+		throwError(errMsg);
       }
 
       if (arguments.length === 9) {
@@ -13295,7 +13322,8 @@
         imageModeConvert = imageModeCenter;
         break;
       default:
-        throw "Invalid imageMode";
+        var errMsg = "Invalid imageMode";
+		throwError(errMsg);
       }
     };
 
@@ -13545,7 +13573,8 @@
      */
     Drawing2D.prototype.bezier = function() {
       if (arguments.length !== 8) {
-        throw("You must use 8 parameters for bezier() in 2D mode");
+        var errMsg = "You must use 8 parameters for bezier() in 2D mode";
+		throwError(errMsg);
       }
 
       p.beginShape();
@@ -13558,7 +13587,8 @@
 
     Drawing3D.prototype.bezier = function() {
       if (arguments.length !== 12) {
-        throw("You must use 12 parameters for bezier() in 3D mode");
+        var errMsg = "You must use 12 parameters for bezier() in 3D mode";
+		throwError(errMsg);
       }
 
       p.beginShape();
@@ -13800,7 +13830,8 @@
 
     Drawing3D.prototype.rect = function(x, y, width, height, tl, tr, br, bl) {
       if (tl !== undef) {
-        throw "rect() with rounded corners is not supported in 3D mode";
+        var errMsg = "rect() with rounded corners is not supported in 3D mode";
+		throwError(errMsg);
       }
 
       if (curRectMode === PConstants.CORNERS) {
@@ -14030,7 +14061,8 @@
     */
     p.normal = function(nx, ny, nz) {
       if (arguments.length !== 3 || !(typeof nx === "number" && typeof ny === "number" && typeof nz === "number")) {
-        throw "normal() requires three numeric arguments.";
+        var errMsg = "normal() requires three numeric arguments.";
+		throwError(errMsg);
       }
 
       normalX = nx;
@@ -14134,7 +14166,8 @@
         getLength: (function(aImg) {
           return function() {
             if (aImg.isRemote) {
-              throw "Image is loaded remotely. Cannot get length.";
+              var errMsg = "Image is loaded remotely. Cannot get length.";
+			  throwError(errMsg);
             } else {
               return aImg.imageData.data.length ? aImg.imageData.data.length/4 : 0;
             }
@@ -14147,7 +14180,8 @@
               data = aImg.imageData.data;
 
             if (aImg.isRemote) {
-              throw "Image is loaded remotely. Cannot get pixels.";
+              var errMsg = "Image is loaded remotely. Cannot get pixels.";
+			  throwError(errMsg);
             }
 
             return (data[offset+3] << 24) & PConstants.ALPHA_MASK |
@@ -14163,7 +14197,8 @@
               data = aImg.imageData.data;
 
             if (aImg.isRemote) {
-              throw "Image is loaded remotely. Cannot set pixel.";
+              var errMsg = "Image is loaded remotely. Cannot set pixel.";
+			  throwError(errMsg);
             }
 
             data[offset+0] = (c & PConstants.RED_MASK) >>> 16;
@@ -14181,7 +14216,8 @@
               length = aImg.width * aImg.height;
 
             if (aImg.isRemote) {
-              throw "Image is loaded remotely. Cannot get pixels.";
+              var errMsg = "Image is loaded remotely. Cannot get pixels.";
+			  throwError(errMsg);
             }
 
             for (var i = 0, offset = 0; i < length; i++, offset += 4) {
@@ -14200,7 +14236,8 @@
               data,
               c;
             if (this.isRemote) {
-              throw "Image is loaded remotely. Cannot set pixels.";
+              var errMsg = "Image is loaded remotely. Cannot set pixels.";
+			  throwError(errMsg);
             }
 
             data = aImg.imageData.data;
@@ -14487,7 +14524,8 @@
       */
       resize: function(w, h) {
         if (this.isRemote) { // Remote images cannot access imageData
-          throw "Image is loaded remotely. Cannot resize.";
+          var errMsg = "Image is loaded remotely. Cannot resize.";
+		  throwError(errMsg);
         }
         if (this.width !== 0 || this.height !== 0) {
           // make aspect ratio if w or h is 0
@@ -14535,7 +14573,8 @@
               // but only the blue color channel
             }
           } else {
-            throw "mask must have the same dimensions as PImage.";
+            var errMsg = "mask must have the same dimensions as PImage.";
+			throwError(errMsg);
           }
         } else if (mask instanceof Array) {
           if (this.width * this.height === mask.length) {
@@ -14543,7 +14582,8 @@
               obj.data[i * 4 + 3] = mask[i];
             }
           } else {
-            throw "mask array must be the same length as PImage pixels array.";
+            var errMsg = "mask array must be the same length as PImage pixels array.";
+			throwError(errMsg);
           }
         }
 
@@ -14577,7 +14617,8 @@
 
       toDataURL: function() {
         if (this.isRemote) { // Remote images cannot access imageData
-          throw "Image is loaded remotely. Cannot create dataURI.";
+          var errMsg = "Image is loaded remotely. Cannot create dataURI.";
+		  throwError(errMsg);
         }
         var canvasData = getCanvasData(this.imageData);
         return canvasData.canvas.toDataURL();
@@ -14740,7 +14781,8 @@
     }
     function get$3(x,y,img) {
       if (img.isRemote) { // Remote images cannot access imageData
-        throw "Image is loaded remotely. Cannot get x,y.";
+        var errMsg = "Image is loaded remotely. Cannot get x,y.";
+		throwError(errMsg);
       }
       // PImage.get(x,y) was called, return the color (int) at x,y of img
       var offset = y * img.width * 4 + (x * 4),
@@ -14758,7 +14800,8 @@
     }
     function get$5(x, y, w, h, img) {
       if (img.isRemote) { // Remote images cannot access imageData
-        throw "Image is loaded remotely. Cannot get x,y,w,h.";
+        var errMsg = "Image is loaded remotely. Cannot get x,y,w,h.";
+		throwError(errMsg);
       }
       // PImage.get(x,y,w,h) was called, return x,y,w,h PImage of img
       // offset start point needs to be *4
@@ -14908,7 +14951,8 @@
     }
     function set$4(x, y, obj, img) {
       if (img.isRemote) { // Remote images cannot access imageData
-        throw "Image is loaded remotely. Cannot set x,y.";
+        var errMsg = "Image is loaded remotely. Cannot set x,y.";
+		throwError(errMsg);
       }
       var c = p.color.toArray(obj);
       var offset = y * img.width * 4 + (x*4);
@@ -15131,10 +15175,12 @@
         obj = arg1;
 
         if (!obj.loaded) {
-          throw "Error using image in background(): PImage not loaded.";
+          var errMsg = "Error using image in background(): PImage not loaded.";
+		  throwError(errMsg);
         }
         if(obj.width !== p.width || obj.height !== p.height){
-          throw "Background image must be the same dimensions as the canvas.";
+          var errMsg = "Background image must be the same dimensions as the canvas.";
+		  throwError(errMsg);
         }
       } else {
         obj = p.color(arg1, arg2, arg3, arg4);
@@ -15397,7 +15443,8 @@
     */
     p.blend = function(src, sx, sy, sw, sh, dx, dy, dw, dh, mode, pimgdest) {
       if (src.isRemote) {
-        throw "Image is loaded remotely. Cannot blend image.";
+        var errMsg = "Image is loaded remotely. Cannot blend image.";
+		throwError(errMsg);
       }
 
       if (mode === undef) {
@@ -15716,7 +15763,8 @@
         param = null;
       }
       if (img.isRemote) { // Remote images cannot access imageData
-        throw "Image is loaded remotely. Cannot filter image.";
+		var errMsg = "Image is loaded remotely. Cannot filter image.";
+		throwError(errMsg);
       }
       // begin filter process
       var imglen = img.pixels.getLength();
@@ -15751,7 +15799,8 @@
 
         case PConstants.POSTERIZE:
           if (param === null) {
-            throw "Use filter(POSTERIZE, int levels) instead of filter(POSTERIZE)";
+            var errMsg = "Use filter(POSTERIZE, int levels) instead of filter(POSTERIZE)";
+			throwError(errMsg);
           }
           var levels = p.floor(param);
           if ((levels < 2) || (levels > 255)) {
@@ -15781,7 +15830,8 @@
             param = 0.5;
           }
           if ((param < 0) || (param > 1)) {
-            throw "Level must be between 0 and 1 for filter(THRESHOLD, level)";
+			var errMsg = "Level must be between 0 and 1 for filter(THRESHOLD, level)";
+			throwError(errMsg);
           }
           var thresh = p.floor(param * 255);
           for (i = 0; i < imglen; i++) {
@@ -16057,7 +16107,8 @@
      */
     p.loadFont = function(name, size) {
       if (name === undef) {
-        throw("font name required in loadFont.");
+        var errMsg = "font name required in loadFont.";
+		throwError(errMsg);
       }
       if (name.indexOf(".svg") === -1) {
         if (size === undef) {
@@ -19501,8 +19552,7 @@
 
             entry[$title] = (new Date()).toLocaleTimeString();
 
-            setStyles(
-            entry, entryStyles, entryText, entryTextStyles);
+            setStyles(entry, entryStyles, entryText, entryTextStyles);
 
             append(entryText, createTextNode(message));
             output.scrollTop = output.scrollHeight;
@@ -19626,7 +19676,8 @@
         func(processing);
         this.attachFunction = func;
       } else {
-        throw "Unable to attach sketch to the processing instance";
+        var errMsg = "Unable to attach sketch to the processing instance";
+		throwError(errMsg);
       }
     };
 //#if PARSER
@@ -19704,10 +19755,12 @@
             try {
               return new Processing(canvas, code.join("\n"));
             } catch(e) {
-              throw "Processing.js: Unable to execute pjs sketch: " + e;
+			  var errMsg = "Unable to execute sketch: " + e;
+			  throwError(errMsg);
             }
-          } else {
-            throw "Processing.js: Unable to load pjs sketch files: " + errors.join("\n");
+          } else {	
+			var errMsg = "Unable to load sketch files: " + errors.join("\n");
+			throwError(errMsg);
           }
         }
       }
@@ -19717,7 +19770,9 @@
         if (scriptElement) {
           callback(scriptElement.text || scriptElement.textContent);
         } else {
-          callback("", "Unable to load pjs sketch: element with id \'" + filename.substring(1) + "\' was not found");
+		  var errMsg = "Unable to load sketch: element with id \'" + filename.substring(1) + "\' was not found";
+		  throwError(errMsg);
+          callback("", errMsg);
         }
         return;
       }
@@ -19798,6 +19853,7 @@
         }
       }
     }
+
   };
 
   /**
@@ -19824,4 +19880,5 @@
     // DOM is not found
     this.Processing = Processing;
   }
+
 }(window, window.document, Math));

--- a/processing.js
+++ b/processing.js
@@ -27,6 +27,7 @@
 	} else {
 		this.error = msg;
 	}
+	throw msg;
   }
 
   var nop = function(){};

--- a/processing.js
+++ b/processing.js
@@ -1,3 +1,18 @@
+/***
+	
+	processing 1.3.6. REVISION 01
+	based on:
+
+    P R O C E S S I N G . J S - 1.3.6
+    a port of the Processing visualization language
+
+    Processing.js is licensed under the MIT License, see LICENSE.
+    For a list of copyright holders, please refer to AUTHORS.
+
+    http://processingjs.org
+
+***/
+
 
 (function(window, document, Math, undef) {
 
@@ -1948,8 +1963,8 @@
     p.frameCount      = 0;
 
     // The height/width of the canvas
-    p.width           = 100;
-    p.height          = 100;
+    p.width           = document.width;		// assuming fullscreen output
+    p.height          = document.height;	// assuming fullscreen output
 
     // "Private" variables used to maintain state
     var curContext,


### PR DESCRIPTION
Hi,

pls find two commits:

the first one is adding a default width/height that auto-initializes to the canvas width/height. I think it's quite useful as you still can change the sketches width/height, but if you don't do anything the sketch as the proper width/height already set.

the second one displays all error messages (additionally) in the "internal" processing console, which is very useful if you're on a device that has no js console. I don't know though if I've take a correct approach on this.

Cheers,
Michael
